### PR TITLE
#56 - 누락된 QueryDSL 설정

### DIFF
--- a/back_end/build.gradle
+++ b/back_end/build.gradle
@@ -62,3 +62,23 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+// QueryDSL적용
+// QClass빌드 장소 정의.
+def generated = 'QClass'
+
+// querydsl QClass파일 생성 위치를 해당 장소로 지정.
+tasks.withType(JavaCompile){
+	options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set에 해당 장소 추가.
+//참고 https://goateedev.tistory.com/73
+sourceSets{
+	main.java.srcDirs += [ generated ]
+}
+
+// gradle clean작업 동작 시,해당 장소도 삭제.
+clean{
+	delete file(generated)
+}


### PR DESCRIPTION
1.  build.gradle에서 QClass 생성 위치를 정의하지 못한 것 수정.
2. QClass의 위치를 새로 정의하고 그 자리에 생성토록 추가 설정함.