### PR TITLE
#36 - Item 관련 수정 사항

### DIFF
--- a/back_end/src/main/java/com/project/shoppingmall/config/JpaConfig.java
+++ b/back_end/src/main/java/com/project/shoppingmall/config/JpaConfig.java
@@ -16,11 +16,12 @@ import java.util.Optional;
 public class JpaConfig {
 
     @Bean
-    public AuditorAware<LoginDto> auditorAware() {
+    public AuditorAware<Long> auditorAware() {
         return () -> Optional.ofNullable(SecurityContextHolder.getContext())
                 .map(SecurityContext::getAuthentication)
                 .filter(Authentication::isAuthenticated)
                 .map(Authentication::getPrincipal)
-                .map(LoginDto.class::cast);
+                .map(LoginDto.class::cast)
+                .map(LoginDto::getId);
     }
 }

--- a/back_end/src/main/java/com/project/shoppingmall/domain/Item.java
+++ b/back_end/src/main/java/com/project/shoppingmall/domain/Item.java
@@ -1,7 +1,6 @@
 package com.project.shoppingmall.domain;
 
 import com.project.shoppingmall.domain.nested.*;
-import com.project.shoppingmall.model.LoginDto;
 import lombok.*;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
@@ -35,7 +34,7 @@ public class Item {
     @Field(type = FieldType.Long)
     private Long price;
     @Field(type = FieldType.Long) @CreatedBy
-    private LoginDto seller;
+    private Long seller;
     @Field(type = FieldType.Text)
     private String imagePath;
 

--- a/back_end/src/main/java/com/project/shoppingmall/domain/nested/Question.java
+++ b/back_end/src/main/java/com/project/shoppingmall/domain/nested/Question.java
@@ -22,6 +22,6 @@ public class Question {
     private String userName;
     @Field(type = FieldType.Text)
     private String content;
-    @Field(type = FieldType.Date, format = DateFormat.basic_date_time) @CreatedDate
+    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second_millis) @CreatedDate
     private LocalDateTime createdAt;
 }

--- a/back_end/src/main/java/com/project/shoppingmall/domain/nested/Review.java
+++ b/back_end/src/main/java/com/project/shoppingmall/domain/nested/Review.java
@@ -21,7 +21,7 @@ public class Review {
     private String option;
     @Field(type = FieldType.Text)
     private String content;
-    @Field(type = FieldType.Date, format = DateFormat.basic_date_time) @CreatedDate
+    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second_millis) @CreatedDate
     private LocalDateTime createdAt;
     @Field(type = FieldType.Object) @Builder.Default
     private List<Like> likes = new ArrayList<>();

--- a/back_end/src/test/java/com/project/shoppingmall/utils/FixtureFactory.java
+++ b/back_end/src/test/java/com/project/shoppingmall/utils/FixtureFactory.java
@@ -13,17 +13,17 @@ import java.util.stream.Stream;
 
 public class FixtureFactory {
     public static final UserDto userDtoFixture = UserDto.builder()
-            .id(1L).createdAt(LocalDateTime.MIN).deletedAt(LocalDateTime.MAX)
+            .id(1L).createdAt(LocalDateTime.now()).deletedAt(null)
             .email("mock email").password("mock password").name("mock name")
             .phoneNum("mock phoneNum").address("mock address")
             .build();
     public static final SellerDto sellerDtoFixture = SellerDto.builder()
-            .id(1L).createdAt(LocalDateTime.MIN).deletedAt(LocalDateTime.MAX)
+            .id(1L).createdAt(LocalDateTime.now()).deletedAt(null)
             .email("mock email").password("mock password").name("mock name")
             .phoneNum("mock phoneNum").address("mock address").companyName("mock companyName")
             .build();
     public static final AdminDto adminDtoFixture = AdminDto.builder()
-            .id(1L).createdAt(LocalDateTime.MIN).deletedAt(LocalDateTime.MAX)
+            .id(1L).createdAt(LocalDateTime.now()).deletedAt(null)
             .email("mock email").password("mock password").name("mock name")
             .phoneNum("mock phoneNum")
             .build();

--- a/back_end/src/test/java/com/project/shoppingmall/utils/WithAuthenticationPrincipal.java
+++ b/back_end/src/test/java/com/project/shoppingmall/utils/WithAuthenticationPrincipal.java
@@ -1,5 +1,6 @@
 package com.project.shoppingmall.utils;
 
+import com.project.shoppingmall.type.RoleType;
 import org.springframework.security.test.context.support.WithSecurityContext;
 
 import java.lang.annotation.Retention;
@@ -8,5 +9,5 @@ import java.lang.annotation.RetentionPolicy;
 @Retention(RetentionPolicy.RUNTIME)
 @WithSecurityContext(factory = WithSecurityContextFactoryImpl.class)
 public @interface WithAuthenticationPrincipal {
-    String role() default "USER";
+    RoleType role() default RoleType.USER;
 }

--- a/back_end/src/test/java/com/project/shoppingmall/utils/WithSecurityContextFactoryImpl.java
+++ b/back_end/src/test/java/com/project/shoppingmall/utils/WithSecurityContextFactoryImpl.java
@@ -11,7 +11,7 @@ public class WithSecurityContextFactoryImpl implements WithSecurityContextFactor
 
     @Override
     public SecurityContext createSecurityContext(WithAuthenticationPrincipal annotation) {
-        RoleType role = RoleType.valueOf(annotation.role());
+        RoleType role = annotation.role();
 
         UserDetails principal = switch (role) {
             case USER -> FixtureFactory.userDtoFixture;


### PR DESCRIPTION
1. Item을 Elastic Search에 저장할 때, 판매자 정보는 넣지 않으므로 판매자의 Id만 삽입하도록 수정.
2. 테스트 시, 유저 정보를 모사할 때 사용하는 @WithAuthenticationPrincipal 의 매개변수가 String 타입이 아닌 Enum 타입을 받을 수 있게 수정.
3. 테스트 시, 유저 정보를 모사할 때 사용하는 @WithAuthenticationPrincipal 에서 사용하는 Fixture의 내용을 살짝 변경