### PR TITLE
#65 - 체크 박스 모음 컴포넌트 설계

### DIFF
--- a/front_end/src/components/search/group_checkbox.vue
+++ b/front_end/src/components/search/group_checkbox.vue
@@ -1,0 +1,42 @@
+<template>
+    <div class="t2b pa-2">
+        <h4 class="my-2">{{ name }}</h4>
+
+        <v-checkbox
+            v-for="option of options" :key="option"
+
+            class="mb-n2" hide-details density="compact"
+            :label="option.label"
+            v-model="option.default"
+        ></v-checkbox>
+
+        <v-divider class="my-3" />
+    </div>
+</template>
+
+<script>
+export default {
+    props: {
+        name: String,
+        options: Array,
+    },
+    computed: {
+        watcherOptions() {
+            let result = new Map();
+            for(const option of this.options) {
+                result.set(option.value, option.default);
+            }
+            return result;
+        }
+    },
+    watch: {
+        watcherOptions(val) {
+            this.$emit("changeOptions", val);
+        }
+    },
+}
+</script>
+
+<style scoped>
+
+</style>


### PR DESCRIPTION
검색 결과창(/search)에서 필터를 걸어 검색결과를 제한할 때,
체크박스 모음이 필요했음.
따라서 해당 컴포넌트를 설계함.