### PR TITLE
#90 - 이름 생성 규칙에 관한 클래스 생성

### DIFF
--- a/back_end/build.gradle
+++ b/back_end/build.gradle
@@ -57,6 +57,9 @@ dependencies {
 //	amazon S3 적용
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+//	FilenameUtils 적용
+	implementation 'commons-io:commons-io:2.5'
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'

--- a/back_end/src/main/java/com/project/shoppingmall/utils/fileManager/S3FileNameManager.java
+++ b/back_end/src/main/java/com/project/shoppingmall/utils/fileManager/S3FileNameManager.java
@@ -1,0 +1,22 @@
+package com.project.shoppingmall.utils.fileManager;
+
+import org.apache.commons.io.FilenameUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.nio.file.Paths;
+
+public class S3FileNameManager {
+    public static final String ROOT_DIR = Paths.get("root", "image").toString();
+
+    public static String makeFileName(MultipartFile multipartFile, String... fileDirs) {
+        String extension = extractExtension(multipartFile);
+
+        String fileNameWithoutExtension = Paths.get(ROOT_DIR, fileDirs).toString();
+        return String.format("%s.%s", fileNameWithoutExtension, extension);
+    }
+
+    public static String extractExtension(MultipartFile multipartFile) {
+        String originalFilename = multipartFile.getOriginalFilename();
+        return FilenameUtils.getExtension(originalFilename);
+    }
+}

--- a/back_end/src/test/java/com/project/shoppingmall/utils/fileManager/S3FileManagerTest.java
+++ b/back_end/src/test/java/com/project/shoppingmall/utils/fileManager/S3FileManagerTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("S3FileManager text - AWS S3 Bucket test")
 @EnableProjectAmazonS3Configuration
 @SetProfile
+// 아래는 Configuration들을 테스트에서 사용하기 위한 장치들이다.
 @DataJpaTest
 @EnableProjectQueryDslConfiguration
 class S3FileManagerTest {
@@ -28,6 +29,7 @@ class S3FileManagerTest {
     FileManager<MultipartFile, String> fileManager;
 
     @Test
+    @DisplayName("[정상 작동][saveFile & deleteFile] S3 파일 저장, 삭제 확인")
     public void givenUrlAndTrgPath_whenCallSaveFileAndDeleteFile_thenExistRelatedUrlInS3Bucket() throws IOException {
         // given
         URL url = new URL("https://cdn.pixabay.com/photo/2016/01/18/19/42/fractal-1147253_960_720.jpg");

--- a/back_end/src/test/java/com/project/shoppingmall/utils/fileManager/S3FileNameManagerTest.java
+++ b/back_end/src/test/java/com/project/shoppingmall/utils/fileManager/S3FileNameManagerTest.java
@@ -1,0 +1,69 @@
+package com.project.shoppingmall.utils.fileManager;
+
+import com.project.shoppingmall.utils.SetProfile;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@SetProfile
+class S3FileNameManagerTest {
+    @Test
+    @DisplayName("[정상 작동][extractExtension] multipartfile에서 확장자 추출.")
+    public void givenMultipart_whenCallExtractExtension_thenReturnExtension() throws IOException {
+        // given
+        URL url = new URL("https://cdn.pixabay.com/photo/2016/01/18/19/42/fractal-1147253_960_720.jpg");
+
+        String originalFilenameWithoutExtension = "originalFilename";
+        String extensionExpected = "jpg";
+        String originalFilename = String.join(".", originalFilenameWithoutExtension, extensionExpected);
+
+        String extensionCalculated;
+
+        //  when
+        try (InputStream inputStream = url.openStream()) {
+            MockMultipartFile image = new MockMultipartFile("image", originalFilename, null, inputStream);
+            extensionCalculated = S3FileNameManager.extractExtension(image);
+        }
+
+        //  then
+        log.debug("Expected:\t{}", extensionExpected);
+        log.debug("Calculated:\t{}", extensionCalculated);
+        assertThat(extensionCalculated).isEqualTo(extensionExpected);
+    }
+
+    @Test
+    @DisplayName("[정상 작동][makeFileName] S3에 저장 시, 사용할 파일 이름 정하는 함수 호출.")
+    public void givenMultipartAndWords_whenCallMakeFileName_thenReturnFileName() throws IOException {
+        // given
+        URL url = new URL("https://cdn.pixabay.com/photo/2016/01/18/19/42/fractal-1147253_960_720.jpg");
+        String originalFilenameWithoutExtension = "originalFilename";
+        String extensionExpected = "jpg";
+        String originalFilename = String.join(".", originalFilenameWithoutExtension, extensionExpected);
+
+        String fileDir1 = "one";
+        String fileDir2 = "two";
+
+        String root = S3FileNameManager.ROOT_DIR;
+        String fileNameExpected = String.join("/", root, fileDir1, fileDir2) + "." + extensionExpected;
+        String fileNameCalculated;
+
+        //  when
+        try (InputStream inputStream = url.openStream()) {
+            MockMultipartFile image = new MockMultipartFile("mock name", originalFilename, null, inputStream);
+            fileNameCalculated = S3FileNameManager.makeFileName(image, fileDir1, fileDir2);
+        }
+
+        //  then
+        log.debug("Expected:\t{}", fileNameExpected);
+        log.debug("Calculated:\t{}", fileNameCalculated);
+        assertThat(fileNameCalculated).isEqualTo(fileNameExpected);
+    }
+}


### PR DESCRIPTION
1. 파일 이름을 보다 쉽게 다룰 수 있게 하는 FilenameUtils 의존성 추가
2. 이미지 파일 이름을 생성하는 클래스인 S3FileNameManager 생성.
3. S3FileNameManager 작동을 확인하는 단위테스트 생성.
4. S3FileManagerTest 관련한 사소한 수정 사항 추가. [ 설명을 위한 주석 등등 추가. ]

더 자세한 것은 #90 