### PR TITLE
#103 - Vue.js - Role에 따른 다른 로그인 수행

### DIFF
--- a/front_end/src/components/login/com_login.vue
+++ b/front_end/src/components/login/com_login.vue
@@ -4,6 +4,28 @@
             <img_logo />
         </v-row>
         <v-row>
+            <v-tabs
+            v-model="role"
+            bg-color="basil" class="mb-3"
+            density="compact" centered stacked grow
+            >
+
+            <v-tab :value="roles.USER">
+                <v-icon>mdi-account</v-icon>
+                소비자
+            </v-tab>
+            <v-tab :value="roles.SELLER">
+                <v-icon>mdi-domain</v-icon>
+                판매자
+            </v-tab>
+            <v-tab :value="roles.ADMIN">
+                <v-icon>mdi-police-badge</v-icon>
+                운영자
+            </v-tab>
+
+            </v-tabs>
+        </v-row>
+        <v-row>
             <v-text-field
                 clearable variant="outlined"
                 :prepend-icon="email.icon" persistent-hint
@@ -47,6 +69,7 @@
 
 <script>
 import { authReq, authRes, ErrRes } from "@/dto";
+import roleType from "@/utils/roleType";
 
 export default {
 data() {return {
@@ -76,11 +99,17 @@ data() {return {
         click: this.onClickJoin,
     },
 
+    role: roleType.roles.USER,
 }},
+computed: {
+    roles() {
+        return roleType.roles;
+    },
+},
 methods: {
     fetchLogin(email, password, isAuto) {
         isAuto
-        const data = authReq.of(email, password);
+        const data = authReq.of(this.role, email, password);
 
         this.clearHint();
         this.$http.post('/auth', data.json())

--- a/front_end/src/dto/index.js
+++ b/front_end/src/dto/index.js
@@ -1,5 +1,3 @@
-import roleType from "@/utils/roleType";
-
 export class authReq {
     constructor(role, email, password) {
         this.role = role;
@@ -7,8 +5,8 @@ export class authReq {
         this.password = password;
     }
 
-    static of(email, password) {
-        return new this(roleType.roles.USER, email, password);
+    static of(role, email, password) {
+        return new this(role, email, password);
     }
 
     json() {


### PR DESCRIPTION
1.  Tabs 형식의 방법으로 '소비자', '판매자', '운영자' 탭을 나눠 로그인을 관리한다.
2. 기존 @/dto/index.js에서는 기본 role값으로 USER값을 설정했는데 이제는 해당 역할은 사용자가 정해줘야 하므로 of 함수에 role파라미터를 추가함.

더 자세한 것은 #103 