### PR TITLE
#115 - 개인 정보 수정 페이지 axios 적용

### DIFF
--- a/front_end/src/views/view_updateAccount.vue
+++ b/front_end/src/views/view_updateAccount.vue
@@ -2,23 +2,18 @@
     <v-container>
         <v-row>
             <v-col>
-                <com_updateAccount :value="data" @update="x=>{tray=x;}"/>
+                <com_updateAccount :value="data" />
             </v-col>
         </v-row>
     </v-container>
 </template>
 
 <script>
+import { LoginRes, ErrRes } from "@/dto";
+
 export default {
     data() {return {
         data: {
-            uid: 1234,
-            email: "asdf@gmail.com",
-            name: "김철수",
-            phoneNum: "010-1234-5678",
-            address: "경기도 김소시 웅무동",
-        },
-        tray: {
             uid: null,
             email: null,
             name: null,
@@ -28,11 +23,47 @@ export default {
     }},
     methods: {
         fetchProfile: async function() {
-            console.log("call fetchProfile");
+            const endPoint = this.$endPoint.backend[this.role];
+
+            // data 업데이트.
+            this.$auth.get(`${endPoint}/principal`)
+            .then(res => {
+                const response = LoginRes.of(res);
+
+                const new_data = {
+                    uid: response.id,
+                    email: response.email,
+                    name: response.name,
+                    phoneNum: response.phoneNum,
+                    address: response.address,
+                };
+
+                this.data = new_data;
+            })
+            .catch(err => {
+                const errorCode = ErrRes.of(err).errorCode;
+                
+                // 에러 메세지 표시.
+                switch(errorCode) {
+                    default:
+                        alert(errorCode);
+                        break;
+                }
+            })
+        },
+    },
+    computed: {
+        role() {
+            return this.$store.state.user.role;
+        }, 
+        isLogin() {
+            return this.$store.getters.isLogin;
         },
     },
     created() {
-        this.fetchProfile();
+        if(this.isLogin) {
+            this.fetchProfile();
+        }
     },
 }
 </script>


### PR DESCRIPTION
1. view_updateAccount.vue에서 페이지 로드 시, 사용자의 개인 정보 내용을 로드하도록 작업.
2. view_updateAccount.vue에서 com_updateAccount 컴포넌트의 @update 이벤트 핸들러를 삭제함.[ 불필요한 요소였음.]
3. 2번에서 언급한 동일한 사유로인해 tray 변수도 삭제함.
4. com_updateAccount에서 정보 수정 성공 시, "수정 완료"라는 글자를 띄우게 함.