### PR TITLE
#121 - 이미지 파일 저장 경로 결정 시, 각 도메인마다 분리

### DIFF
--- a/back_end/src/main/java/com/project/shoppingmall/service/AdImgServiceImpl.java
+++ b/back_end/src/main/java/com/project/shoppingmall/service/AdImgServiceImpl.java
@@ -58,7 +58,7 @@ public class AdImgServiceImpl implements AdImgService {
 
         // 배너 이미지가 존재한다면, 이미지 저장 후, 이미지 링크를 DB에 저장.
         if (!path.isEmpty()) {
-            String fileName = makeFileName(path, id, ImageType.AD_BANNER.getName());
+            String fileName = makeFileName(path, AdImg.class, id, ImageType.AD_BANNER.getName());
             entity.setPath(saveFile(path, fileName));
         }
     }

--- a/back_end/src/main/java/com/project/shoppingmall/service/ItemServiceImpl.java
+++ b/back_end/src/main/java/com/project/shoppingmall/service/ItemServiceImpl.java
@@ -80,7 +80,7 @@ public class ItemServiceImpl implements ItemService {
 
         // 상품 대표 이미지 저장.
         if (isThereMainImage) {
-            String trgPath = makeFileName(request.getImage(), iid, ImageType.MAIN.getName());
+            String trgPath = makeFileName(request.getImage(), Item.class, iid, ImageType.MAIN.getName());
             entity.setImagePath(saveFile(request.getImage(), trgPath));
         }
 
@@ -89,7 +89,7 @@ public class ItemServiceImpl implements ItemService {
             List<MultipartFile> descriptionList = request.getDescriptionList();
             for(int i = 0; i < descriptionList.size(); i++) {
                 MultipartFile descriptionFile = descriptionList.get(i);
-                String imgPath = makeFileName(descriptionFile, iid, ImageType.DESC.getName(i));
+                String imgPath = makeFileName(descriptionFile, Item.class, iid, ImageType.DESC.getName(i));
                 Description description = Description.builder().path(saveFile(descriptionFile, imgPath)).build();
                 entity.addDescriptionList(description);
             }

--- a/back_end/src/main/java/com/project/shoppingmall/utils/fileManager/S3FileNameManager.java
+++ b/back_end/src/main/java/com/project/shoppingmall/utils/fileManager/S3FileNameManager.java
@@ -3,15 +3,30 @@ package com.project.shoppingmall.utils.fileManager;
 import org.apache.commons.io.FilenameUtils;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.File;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 public class S3FileNameManager {
     public static final String ROOT_DIR = Paths.get("root", "image").toString();
 
-    public static String makeFileName(MultipartFile multipartFile, String... fileDirs) {
-        String extension = extractExtension(multipartFile);
+    public static <T> String makeFileName(MultipartFile multipartFile, Class<T> clazz, String... fileDirs) {
+        List<String> dirs = new ArrayList<>();
 
-        String fileNameWithoutExtension = Paths.get(ROOT_DIR, fileDirs).toString();
+        // 루트 경로.
+        dirs.add(ROOT_DIR);
+
+        // 도메인 이름 경로.
+        dirs.add(clazz.getSimpleName());
+
+        // 나머지 경로.
+        dirs.addAll(List.of(fileDirs));
+
+        String extension = extractExtension(multipartFile);
+        String separator = File.separator;
+
+        String fileNameWithoutExtension = String.join(separator, dirs);
         return String.format("%s.%s", fileNameWithoutExtension, extension);
     }
 

--- a/back_end/src/test/java/com/project/shoppingmall/utils/fileManager/S3FileNameManagerTest.java
+++ b/back_end/src/test/java/com/project/shoppingmall/utils/fileManager/S3FileNameManagerTest.java
@@ -48,17 +48,18 @@ class S3FileNameManagerTest {
         String extensionExpected = "jpg";
         String originalFilename = String.join(".", originalFilenameWithoutExtension, extensionExpected);
 
+        Class<Object> clazz = Object.class;
         String fileDir1 = "one";
         String fileDir2 = "two";
 
         String root = S3FileNameManager.ROOT_DIR;
-        String fileNameExpected = String.join("/", root, fileDir1, fileDir2) + "." + extensionExpected;
+        String fileNameExpected = String.join("/", root, clazz.getSimpleName(), fileDir1, fileDir2) + "." + extensionExpected;
         String fileNameCalculated;
 
         //  when
         try (InputStream inputStream = url.openStream()) {
             MockMultipartFile image = new MockMultipartFile("mock name", originalFilename, null, inputStream);
-            fileNameCalculated = S3FileNameManager.makeFileName(image, fileDir1, fileDir2);
+            fileNameCalculated = S3FileNameManager.makeFileName(image, clazz, fileDir1, fileDir2);
         }
 
         //  then


### PR DESCRIPTION
1. 기존 네이밍 규칙: root/image/ID/name.jpg 새로운 네이밍 규칙: root/image/Object/ID/name.jpg
2. 네이밍 규칙을 담당하는 S3FileNameManager.makeFileName을 변경.
3. S3FileNameManager을 사용하고 있던 AdImgServiceImpl와 ItemServiceImpl을 수정.
4. 바뀐 네이밍 규칙에 따라 테스트 코드도 수정.

더 자세한 것은 #121 