### PR TITLE
#126 - multipart 형식 데이터는 get, post 이외의 메서드로 전송 불가 버그

### DIFF
--- a/back_end/src/main/java/com/project/shoppingmall/controller/AdImgController.java
+++ b/back_end/src/main/java/com/project/shoppingmall/controller/AdImgController.java
@@ -20,25 +20,25 @@ public class AdImgController {
     private final AdImgService adImgService;
 
     @PostMapping
-    public Response<Void> createUser( @ModelAttribute @Valid AdImgCreateRequest request) {
+    public Response<Void> create( @ModelAttribute @Valid AdImgCreateRequest request) {
         adImgService.create(request);
         return Response.success();
     }
 
     @GetMapping
-    public Response<Page<AdImgReadResponse>> readUser(@PageableDefault Pageable pageable) {
+    public Response<Page<AdImgReadResponse>> read(@PageableDefault Pageable pageable) {
         Page<AdImgReadResponse> pages = adImgService.read(pageable);
         return Response.success(pages);
     }
 
     @GetMapping("/{aid}")
-    public Response<AdImgReadResponse> readUser(@PathVariable Long aid) {
+    public Response<AdImgReadResponse> read(@PathVariable Long aid) {
         AdImgReadResponse dto = adImgService.read(aid);
         return Response.success(dto);
     }
 
-    @PutMapping("/{aid}")
-    public Response<Void> updateUser(
+    @PostMapping("/{aid}")
+    public Response<Void> update(
             @PathVariable Long aid,
             @ModelAttribute @Valid AdImgUpdateRequest request
     ) {
@@ -47,7 +47,7 @@ public class AdImgController {
     }
 
     @DeleteMapping("/{aid}")
-    public Response<Void> deleteUser(@PathVariable Long aid) {
+    public Response<Void> delete(@PathVariable Long aid) {
         adImgService.delete(aid);
         return Response.success();
     }

--- a/front_end/src/components/adManage/com_ad_manage.vue
+++ b/front_end/src/components/adManage/com_ad_manage.vue
@@ -143,7 +143,8 @@ export default {
             formData.append(AdImgReq.params.endAt, this.input.endAt.value);
 
             // 아이디가 존재하면 post 방식으로, 아이디가 존재하지 않으면 put 방식으로.
-            const promise = id ? this.$auth.put(`/adimg/${id}`, formData) : this.$auth.post(`/adimg`, formData);
+            const endPoint = id ? `/adimg/${id}` : `/adimg`
+            const promise = this.$auth.post(endPoint, formData, {headers: {'Context-Type': 'multipart/form-data'}})
 
             promise.then(() => {
                 // 데이터 새로고침.


### PR DESCRIPTION
1. 기존에 put 메소드를 수정하던 것을 post로 수정하기로 변경함.
2. Vue.js에서 전송 메소드를 통일시킴.