### PR TITLE
#127 - multipart 파일이 null일 경우, .isEmpty 메서드 호출 불가 버그

### DIFF
--- a/back_end/src/main/java/com/project/shoppingmall/service/AdImgServiceImpl.java
+++ b/back_end/src/main/java/com/project/shoppingmall/service/AdImgServiceImpl.java
@@ -57,7 +57,7 @@ public class AdImgServiceImpl implements AdImgService {
         MultipartFile path = request.getPath();
 
         // 배너 이미지가 존재한다면, 이미지 저장 후, 이미지 링크를 DB에 저장.
-        if (!path.isEmpty()) {
+        if (path != null && !path.isEmpty()) {
             String fileName = makeFileName(path, AdImg.class, id, ImageType.AD_BANNER.getName());
             entity.setPath(saveFile(path, fileName));
         }


### PR DESCRIPTION
1. AdImg[배너 광고 이미지 도메인]에서 formData에 Multipart 형식 데이터가 존재하는 경우에만 이미지 저장하도록 구성함.