### PR TITLE
#139 - 개인 정보 수정 페이지에 정보 수정이 안되는 버그 발견

### DIFF
--- a/front_end/src/components/updateAccount/com_updateAccount.vue
+++ b/front_end/src/components/updateAccount/com_updateAccount.vue
@@ -151,14 +151,15 @@ export default {
             } else {
                 this.error = "";
             }
-            // TODO: axios를 이용해서 업데이트 쿼리 날리기.
+            // axios를 이용해서 업데이트 쿼리 날리기.
             const role = this.$store.state.user.role;
             const data = UserUpdateReq.of(role, this.model);
             const endpoint = this.$endPoint.backend[role];
 
             this.$auth.put(`${endpoint}/principal`, data.json())
             .then(() => {
-                this.setError("수정 완료")
+                this.setError("수정 완료");
+                this.$emit('fetchProfile');
             })
             .catch(err => {
                 const errorCode = ErrRes.of(err).errorCode;

--- a/front_end/src/dto/index.js
+++ b/front_end/src/dto/index.js
@@ -85,30 +85,30 @@ export class UserUpdateReq {
         switch (this.role) {
             case roleType.roles.USER:
                 return {
-                    uid: this.data("id"),
+                    id: this.data("uid"),
                     email: this.data("email"),
                     password: this.data("password"),
                     name: this.data("name"),
-                    phoneNum: this.data("phone"),
+                    phoneNum: this.data("phoneNum"),
                     address: this.data("address"),
                 };
             case roleType.roles.SELLER:
                 return {
-                    uid: this.data("id"),
+                    id: this.data("uid"),
                     email: this.data("email"),
                     password: this.data("password"),
                     name: this.data("name"),
-                    phone: this.data("phone"),
+                    phoneNum: this.data("phoneNum"),
                     companyName: this.data("companyName"),
                     address: this.data("address"),
                 };
             case roleType.roles.ADMIN:
                 return {
-                    uid: this.data("id"),
+                    id: this.data("uid"),
                     email: this.data("email"),
                     password: this.data("password"),
                     name: this.data("name"),
-                    phone: this.data("phone"),
+                    phoneNum: this.data("phoneNum"),
                     address: this.data("address"),
                 };
         

--- a/front_end/src/views/view_updateAccount.vue
+++ b/front_end/src/views/view_updateAccount.vue
@@ -2,7 +2,7 @@
     <v-container>
         <v-row>
             <v-col>
-                <com_updateAccount :value="data" />
+                <com_updateAccount :value="data" @fetchProfile="fetchProfile" />
             </v-col>
         </v-row>
     </v-container>


### PR DESCRIPTION
1. 기존의 request 파라미터 네이밍이 이상하게 되어 있음을 발견하여 그 부분에 대한 버그를 수정함.
2. 수정하기 버튼을 누르면 정보를 reloading하게 만들었다.

더 자세한 것은 #139 