### PR TITLE
#149 - 홈화면 태그에 따른 상품들 출력

### DIFF
--- a/back_end/src/main/java/com/project/shoppingmall/controller/TagController.java
+++ b/back_end/src/main/java/com/project/shoppingmall/controller/TagController.java
@@ -1,0 +1,37 @@
+package com.project.shoppingmall.controller;
+
+import com.project.shoppingmall.model.response.ItemReadResponse;
+import com.project.shoppingmall.model.response.Response;
+import com.project.shoppingmall.model.response.TagReadResponse;
+import com.project.shoppingmall.service.TagService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/tag")
+@RequiredArgsConstructor
+public class TagController {
+    private final TagService tagService;
+
+    @GetMapping
+    public Response<Page<TagReadResponse>> search(@PageableDefault Pageable pageable) {
+        Page<TagReadResponse> page = tagService.getRandomTags(pageable)
+                .map(TagReadResponse::fromEntity);
+        return Response.success(page);
+    }
+
+    @GetMapping("/{name}/item")
+    public Response<Page<ItemReadResponse>> search(
+            @PathVariable String name,
+            @PageableDefault Pageable pageable
+            ) {
+        Page<ItemReadResponse> page = tagService.getItems(name, pageable);
+        return Response.success(page);
+    }
+}

--- a/back_end/src/main/java/com/project/shoppingmall/domain/nested/Tag.java
+++ b/back_end/src/main/java/com/project/shoppingmall/domain/nested/Tag.java
@@ -7,7 +7,7 @@ import org.springframework.data.elasticsearch.annotations.FieldType;
 @NoArgsConstructor @Getter @Setter
 @AllArgsConstructor @Builder(toBuilder = true)
 public class Tag {
-    @Field(type = FieldType.Text)
+    @Field(type = FieldType.Keyword)
     private String name;
 
     public static Tag of(Tag trg) {

--- a/back_end/src/main/java/com/project/shoppingmall/model/response/TagReadResponse.java
+++ b/back_end/src/main/java/com/project/shoppingmall/model/response/TagReadResponse.java
@@ -1,0 +1,15 @@
+package com.project.shoppingmall.model.response;
+
+import com.project.shoppingmall.domain.nested.Tag;
+import lombok.*;
+
+@AllArgsConstructor @Getter @Builder
+public class TagReadResponse {
+    private String name;
+
+    public static TagReadResponse fromEntity(Tag entity) {
+        return TagReadResponse.builder()
+                .name(entity.getName())
+                .build();
+    }
+}

--- a/back_end/src/main/java/com/project/shoppingmall/repository/KeywordRepository.java
+++ b/back_end/src/main/java/com/project/shoppingmall/repository/KeywordRepository.java
@@ -1,8 +1,14 @@
 package com.project.shoppingmall.repository;
 
+import com.project.shoppingmall.domain.Item;
+import com.project.shoppingmall.domain.nested.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface KeywordRepository<T> {
     Page<T> findByKeyword(String keyword, Pageable pageable);
+    List<Tag> findDistinctTag();
+    Page<Item> findByTagName(String tagName, Pageable pageable);
 }

--- a/back_end/src/main/java/com/project/shoppingmall/repository/querydsl/ItemRepositoryImpl.java
+++ b/back_end/src/main/java/com/project/shoppingmall/repository/querydsl/ItemRepositoryImpl.java
@@ -1,21 +1,28 @@
 package com.project.shoppingmall.repository.querydsl;
 
 import com.project.shoppingmall.domain.Item;
+import com.project.shoppingmall.domain.nested.Tag;
 import com.project.shoppingmall.repository.KeywordRepository;
 import lombok.RequiredArgsConstructor;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
+import org.elasticsearch.search.aggregations.bucket.terms.ParsedStringTerms;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.ElasticsearchAggregations;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static org.elasticsearch.index.query.QueryBuilders.*;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 
 @RequiredArgsConstructor
 public class ItemRepositoryImpl implements KeywordRepository<Item> {
@@ -25,6 +32,50 @@ public class ItemRepositoryImpl implements KeywordRepository<Item> {
     public Page<Item> findByKeyword(String keyword, Pageable pageable) {
         QueryBuilder query = boolQuery()
                 .should(matchQuery("name", keyword));
+
+        SearchHits<Item> result = elasticsearchClient.search(
+                new NativeSearchQueryBuilder()
+                        .withQuery(query)
+                        .withPageable(pageable)
+                        .build(),
+                Item.class
+        );
+
+        List<Item> items = result.getSearchHits().stream()
+                .map(SearchHit::getContent)
+                .toList();
+        return new PageImpl<>(items, pageable, result.getTotalHits());
+    }
+
+    @Override
+    public List<Tag> findDistinctTag() {
+        String AGG_NAME = "distinct_tags";
+        TermsAggregationBuilder query = terms(AGG_NAME).field("tagList.name");
+
+        SearchHits<Item> result = elasticsearchClient.search(
+                new NativeSearchQueryBuilder()
+                        .withQuery(matchAllQuery())
+                        .withAggregations(query)
+                        .build(),
+                Item.class
+        );
+
+        return Optional.of(result)
+                .map(SearchHits::getAggregations)
+                .map(ElasticsearchAggregations.class::cast)
+                .map(ElasticsearchAggregations::aggregations)
+                .map(agg -> agg.get(AGG_NAME))
+                .map(ParsedStringTerms.class::cast)
+                .map(ParsedStringTerms::getBuckets)
+                .stream().flatMap(Collection::stream)
+                .map(MultiBucketsAggregation.Bucket::getKeyAsString)
+                .map(s -> Tag.builder().name(s).build())
+                .toList();
+    }
+
+    @Override
+    public Page<Item> findByTagName(String tagName, Pageable pageable) {
+        QueryBuilder query = matchQuery("tagList.name", tagName);
 
         SearchHits<Item> result = elasticsearchClient.search(
                 new NativeSearchQueryBuilder()

--- a/back_end/src/main/java/com/project/shoppingmall/service/TagService.java
+++ b/back_end/src/main/java/com/project/shoppingmall/service/TagService.java
@@ -1,0 +1,11 @@
+package com.project.shoppingmall.service;
+
+import com.project.shoppingmall.domain.nested.Tag;
+import com.project.shoppingmall.model.response.ItemReadResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface TagService {
+    Page<Tag> getRandomTags(Pageable pageable);
+    Page<ItemReadResponse> getItems(String tagName, Pageable pageable);
+}

--- a/back_end/src/main/java/com/project/shoppingmall/service/TagServiceImpl.java
+++ b/back_end/src/main/java/com/project/shoppingmall/service/TagServiceImpl.java
@@ -1,0 +1,34 @@
+package com.project.shoppingmall.service;
+
+import com.project.shoppingmall.domain.nested.Tag;
+import com.project.shoppingmall.model.response.ItemReadResponse;
+import com.project.shoppingmall.repository.ItemRepository;
+import com.project.shoppingmall.utils.RandomUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class TagServiceImpl implements TagService {
+    private final ItemRepository itemRepository;
+
+    @Override
+    public Page<Tag> getRandomTags(Pageable pageable) {
+        List<Tag> tags = itemRepository.findDistinctTag();
+        List<Tag> tagsSelected = RandomUtils.sample(tags, pageable.getPageSize());
+        return new PageImpl<>(tagsSelected, pageable, tagsSelected.size());
+    }
+
+    @Override
+    public Page<ItemReadResponse> getItems(String tagName, Pageable pageable) {
+        return itemRepository.findByTagName(tagName, pageable)
+                .map(ItemReadResponse::fromEntity);
+    }
+}

--- a/back_end/src/main/java/com/project/shoppingmall/utils/RandomUtils.java
+++ b/back_end/src/main/java/com/project/shoppingmall/utils/RandomUtils.java
@@ -1,0 +1,23 @@
+package com.project.shoppingmall.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.lang.Math.min;
+
+public class RandomUtils {
+    public static <E> List<E> sample(List<E> list, int size) {
+        java.util.Random random = new java.util.Random();
+        int size_ = min(size, list.size());
+
+        List<Integer> set = new ArrayList<>();
+
+        while (set.size() < size_) {
+            int idx = random.nextInt(list.size());
+            if(!set.contains(idx)) {
+                set.add(idx);
+            }
+        }
+        return set.stream().map(list::get).toList();
+    }
+}

--- a/back_end/src/test/java/com/project/shoppingmall/repository/ItemRepositoryTest.java
+++ b/back_end/src/test/java/com/project/shoppingmall/repository/ItemRepositoryTest.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
 import java.util.*;
 import java.util.stream.Stream;
@@ -31,32 +32,43 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest
 class ItemRepositoryTest {
     private final List<Item> fixtures = new ArrayList<>();
+    private final Set<String> tableTagNames = new HashSet<>();
     @Autowired
     ItemRepository itemRepository;
+    private List<Item> items;
 
     @BeforeEach
     void saveTestCase() {
         // fixtures
         List<Item> fixturesBeforeSaving = new ArrayList<>();
 
-        Tag tag = new Tag();
-        tag.setName("컴퓨터");
+        Tag tag1 = Tag.builder().name("컴퓨터").build();
+        Tag tag2 = Tag.builder().name("TV").build();
+        Tag tag3 = Tag.builder().name("가전제품").build();
+        tableTagNames.add(tag1.getName());
+        tableTagNames.add(tag2.getName());
+        tableTagNames.add(tag3.getName());
 
         Item entity1 = new Item();
         entity1.setName("GPU 4080");
         entity1.setPrice(15000L);
-        entity1.addTagList(tag);
+        entity1.addTagList(tag1);
+        entity1.addTagList(tag2);
         entity1.setSeller(1L);
         fixturesBeforeSaving.add(entity1);
 
         Item entity2 = new Item();
         entity2.setName("GPU 1080");
         entity2.setPrice(10000L);
+        entity2.addTagList(tag1);
+        entity2.addTagList(tag3);
         fixturesBeforeSaving.add(entity2);
 
         // save all
         Iterable<Item> itemsSaved = itemRepository.saveAll(fixturesBeforeSaving);
-        fixtures.addAll(StreamSupport.stream(itemsSaved.spliterator(), false).toList());
+
+        items = StreamSupport.stream(itemsSaved.spliterator(), false).toList();
+        fixtures.addAll(items);
     }
 
     @AfterEach
@@ -92,5 +104,79 @@ class ItemRepositoryTest {
         // then
         hits.map(Item::toString).forEach(log::debug);
         hits.map(Item::getName).forEach(name -> assertThat(name).contains(keyword));
+    }
+
+    @Test
+    @DisplayName("[정상 구동][findByKeyword] keyword를 이용해서 검색을 시도할 때, 정렬 기능 정상 작동.")
+    void givenKeywordAndSort_whenCallFindByKeyword_thenGivePageOfItem() {
+        // given
+        String keyword = "GPU";
+        PageRequest pageAsc = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "price"));
+        PageRequest pageDesc = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "price"));
+
+        // when
+        Page<Item> hitsAsc = itemRepository.findByKeyword(keyword, pageAsc);
+        Page<Item> hitsDesc = itemRepository.findByKeyword(keyword, pageDesc);
+
+        // then
+        log.debug("가격 기준 오름차순");
+        hitsAsc.map(Item::toString).forEach(log::debug);
+
+        log.debug("가격 기준 내림차순");
+        hitsDesc.map(Item::toString).forEach(log::debug);
+
+        List<Long> listAsc = hitsAsc.stream().map(Item::getPrice).toList();
+        List<Long> listDesc = hitsDesc.stream().map(Item::getPrice).toList();
+        assertThat(listAsc.get(0) <= listAsc.get(1)).isTrue();
+        assertThat(listDesc.get(0) >= listDesc.get(1)).isTrue();
+    }
+
+    @Test
+    @DisplayName("[정상 구동][findByKeyword] keyword를 이용해서 검색을 시도할 때, countQuery 정상 작동.")
+    void givenKeyword_whenCallFindByKeyword_thenGiveTotalPages() {
+        // given
+        String keyword = "GPU";
+        PageRequest page = PageRequest.of(0, 1);
+
+        // when
+        Page<Item> hits = itemRepository.findByKeyword(keyword, page);
+
+        // then
+        log.debug("검색된 총 갯수: {}, 실제 갯수: {}", hits.getTotalElements(), items.size());
+        assertThat(hits.getTotalElements()).isNotEqualTo(page.getPageSize());
+    }
+
+    @Test
+    @DisplayName("[정상 구동][findDistinctTag] Item에 종속된 Tags 호출.")
+    void givenNothing_whenCallFindDistinctTag_thenGiveListOfTags() {
+        // given
+
+        // when
+        List<Tag> hits = itemRepository.findDistinctTag();
+
+        // then
+        hits.forEach(tag -> {
+            log.debug("검색된 태그명: {}", tag.getName());
+            assertThat(tag.getName()).isIn(tableTagNames);
+        });
+    }
+
+    @Test
+    @DisplayName("[정상 구동][findByTagName] 주어진 Tag명을 내포한 아이템 검색.")
+    void givenTagName_whenCallFindByTagName_thenGivePageOfItems() {
+        // given
+        String tagName = "TV";
+        PageRequest pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<Item> hits = itemRepository.findByTagName(tagName, pageable);
+
+        // then
+        hits.forEach(item -> {
+            log.debug("검색된 상품명: {}", item.getName());
+
+            List<String> tagNameList = item.getTagList().stream().map(Tag::getName).toList();
+            assertThat(tagName).isIn(tagNameList);
+        });
     }
 }

--- a/back_end/src/test/java/com/project/shoppingmall/utils/RandomUtilsTest.java
+++ b/back_end/src/test/java/com/project/shoppingmall/utils/RandomUtilsTest.java
@@ -1,0 +1,40 @@
+package com.project.shoppingmall.utils;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+class RandomUtilsTest {
+    @Test
+    void givenList_whenCallSample_thenRandomList() {
+        // given
+        List<String> list = List.of("A", "B", "C", "D", "E", "F");
+        int size = 2;
+
+        // when
+        List<String> sample = RandomUtils.sample(list, size);
+
+        // then
+        assertThat(sample.size()).isEqualTo(size);
+        sample.forEach(log::debug);
+    }
+
+    @Test
+    void givenListAndTooMuchSize_whenCallSample_thenRandomList() {
+        // given
+        List<String> list = List.of("A", "B", "C", "D", "E", "F");
+        int size = 10000;
+
+        // when
+        List<String> sample = RandomUtils.sample(list, size);
+
+        // then
+        assertThat(sample.size()).isEqualTo(list.size());
+        sample.forEach(log::debug);
+    }
+
+}

--- a/front_end/README.md
+++ b/front_end/README.md
@@ -24,7 +24,8 @@ npm run lint
 ```
 Vue.Js : 3.2.13
 Vue/cli : 5.0.8
-Node.Js : 8.11.0
+npm : 8.11.0
+npm : v16.16.0
 Vue Router : 4.1.5
 Vuex : 4.0.2
 Vuetify : 3.0.0-beta.0

--- a/front_end/src/components/home/category_items.vue
+++ b/front_end/src/components/home/category_items.vue
@@ -37,11 +37,15 @@ export default {
             type: Number,
             default: 3,
         },
+        items: {
+            type: Array,
+            default: new Array(),
+        },
     },
     data() {return {
         page: 0,
         data: {
-            items: [1,2,3,4,5,6,7,8,9,10,11,12,13],
+            items: this.items,
             mockItem: null
         },
         caluated: {
@@ -56,6 +60,12 @@ export default {
         },
         getItem(page, row, col) {
             return this.caluated.items[this.$util.getIdx(page, row, col, this.rows, this.cols)]
+        },
+    },
+    watch: {
+        items(val) {
+            this.data.items = val;
+            this.setPagesNItems();
         },
     },
     mounted() {

--- a/front_end/src/components/home/category_name.vue
+++ b/front_end/src/components/home/category_name.vue
@@ -1,33 +1,31 @@
 <template>  
     <v-container class="y-gap">
         <v-row class="t2b">
-            <h1>{{ data.category.name ?? $defaults.category }}</h1>
+            <h1>태그명:</h1>
             <br>
-            <h6
-                class="clickable"
-                @click="onClickLink(data.category.link)"
-            >바로가기 ></h6>
-        </v-row>
-        <v-row class="t2b">
-            <h3>HOT 키워드</h3>
+            <h2>{{ data.category.name ?? $defaults.category }}</h2>
         </v-row>
     </v-container>
 </template>
 
 <script>
 export default {
+props: {
+    name: {
+        type: String,
+        default: null,
+    },
+},
 data() {return {
     data: {
         category: {
-            name: null,
-            link: null,
-
+            name: this.name,
         }
     },
 }},
-methods: {
-    onClickLink(link) {
-        this.$router.push(link ?? this.$defaults.link);
+watch: {
+    name(val) {
+        this.data.category.name = val;
     },
 },
 }

--- a/front_end/src/components/home/com_display.vue
+++ b/front_end/src/components/home/com_display.vue
@@ -2,13 +2,13 @@
 <v-container>
 <v-row class="noGap border-line" align="center">
     <v-col cols="auto">
-        <category_name />
+        <category_name :name="name"/>
     </v-col>
 
     <v-divider vertical />
     
     <v-col>
-        <category_items />
+        <category_items :items="items"/>
     </v-col>
 </v-row>
 </v-container>
@@ -16,7 +16,16 @@
 
 <script>
 export default {
-
+    props: {
+        items: {
+            type: Array,
+            default: new Array(),
+        },
+        name: {
+            type: String,
+            default: "빈 카테고리",
+        },
+    },
 }
 </script>
 

--- a/front_end/src/components/home/com_item.vue
+++ b/front_end/src/components/home/com_item.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-container class="t2b center">
+    <v-container v-if="data" class="t2b center">
         <com_img class="box x-center size-limit" v-bind="data" />
         <h5>{{ data.name }}</h5>
         <h5>{{ `${$util.transPrice(data.price)}원` }}</h5>
@@ -9,16 +9,8 @@
 <script>
 export default {
     props: {
-        data_retained: Number,
+        data: Object,
     },
-    data() {return {
-        data: {
-            src: "https://thumbnail6.coupangcdn.com/thumbnails/remote/160x160ex/image/vendor_inventory/2330/addbde5c0bf9d3c4962ed113d0d2f831aa7ed419b13dfbd77fbdd805c63f.jpg",
-            link: null,
-            name: "존재하지 않는 아이템",
-            price: 1234253,
-        }
-    }},
 }
 </script>
 

--- a/front_end/src/views/view_home.vue
+++ b/front_end/src/views/view_home.vue
@@ -6,33 +6,24 @@
             <com_img :src="bannerSrc" :link="bannerLink"/>
         </v-col>
     </v-row>
-    <v-row justify="center">
+    <v-row justify="center"
+        v-for="(val, key) in tags" :key="key"
+    >
         <v-col>
-            전체 고객에 대한 추천 섹션
-            <com_display />
-        </v-col>
-    </v-row>
-    <v-row justify="center">
-        <v-col>
-            카테고리별 추천 섹션
-            <com_display />
-        </v-col>
-    </v-row>
-    <v-row justify="center">
-        <v-col>
-            고객별 맞춤 추천 섹션
-            <com_display />
+            <com_display :name="key" :items="val" />
         </v-col>
     </v-row>
 </v-container>
 </template>
 
 <script>
-import { ErrRes, AdImgRecommendRes } from '@/dto';
+import { ErrRes, AdImgRecommendRes, PageReq, TagRes, ItemSearchedRes } from '@/dto';
 
 export default {
     data() {return {
         trayAdBanner: null,
+
+        tags: {},
     }},
     computed: {
         bannerSrc() {
@@ -59,9 +50,45 @@ export default {
                 }
             });
         },
+        fetchRandomTags() {
+            const page = PageReq.of(0, 3);
+            this.$http.get(`/tag`, {params: page.params()}).then(res => {
+                const response = TagRes.of(res);
+                for(const tag of response.pages()) {
+                    const tagName = tag.name;
+                    this.fetchItemsByTag(tagName);
+                }
+            }).catch(err => {
+                const errorCode = ErrRes.of(err).errorCode;
+
+                // 에러 메세지 표시.
+                switch(errorCode) {
+                    default:
+                        alert(errorCode);
+                        break;
+                }
+            });
+        },
+        fetchItemsByTag(tagName) {
+            const page = PageReq.of(0, 18);
+            this.$http.get(`/tag/${tagName}/item`, {params: page.params()}).then(res => {
+                const response = ItemSearchedRes.of(res);
+                this.tags[tagName] = response.pages();
+            }).catch(err => {
+                const errorCode = ErrRes.of(err).errorCode;
+
+                // 에러 메세지 표시.
+                switch(errorCode) {
+                    default:
+                        alert(errorCode);
+                        break;
+                }
+            });
+        },
     },
     mounted() {
         this.loadAdBanner();
+        this.fetchRandomTags();
     }
 }
 </script>


### PR DESCRIPTION
-> 프론트 레이어
1. 첫 화면 로드 시, 랜덤으로 태그를 픽하고 그 태그를 가진 아이템들을 로드함.
2. 기존에 임의로 잡아두었던 컴포넌트들의 props를 정비함.

-> 백엔드 레이어
1. aggregation에 사용하기 위해 Tag 엔티티의 name 필드 타입을 Keyword로 변경.
2. Controller 레이어 코드 구현
3. Service 레이어 코드 구현
4. RandomUtils의 Sample 메서드를 구현해서 List에서 무작위 요소 추출하기.
5. RandomUtils를 테스트하기 위해 RandomUtilsTest를 만들어 테스트함.
6. Repository 레이어 코드 구현 및 이에 따른 테스트 코드 작성.