### PR TITLE
#176 - 상품 검색 시 검색 관련도순 정렬 구현.

### DIFF
--- a/front_end/src/cfg/env.js
+++ b/front_end/src/cfg/env.js
@@ -16,8 +16,9 @@ export default {
             value: "name", 
             api: "/item",
             btnSet: {
-                init_btn: "date-desc",
+                init_btn: "relevant-desc",
                 btns: {
+                    "relevant-desc": {label: "관련도순", json: {trg: null, isAsc: false,},},
                     "date-desc": {label: "최신순", json: {trg: "createdAt", isAsc: false,},},
                     "price-asc": {label: "낮은 가격순", json: {trg: "price", isAsc: true,},},
                     "price-desc": {label: "높은 가격순", json: {trg: "price", isAsc: false,},},
@@ -29,8 +30,9 @@ export default {
             value: "review", 
             api: "/review",
             btnSet: {
-                init_btn: "date-desc",
+                init_btn: "relevant-desc",
                 btns: {
+                    "relevant-desc": {label: "관련도순", json: {trg: null, isAsc: false,},},
                     "date-desc": {label: "최신순", json: {trg: "createdAt", isAsc: false,},},
                 },
             },
@@ -40,8 +42,9 @@ export default {
             value: "qna", 
             api: "/question",
             btnSet: {
-                init_btn: "date-desc",
+                init_btn: "relevant-desc",
                 btns: {
+                    "relevant-desc": {label: "관련도순", json: {trg: null, isAsc: false,},},
                     "date-desc": {label: "최신순", json: {trg: "createdAt", isAsc: false,},},
                 },
             },


### PR DESCRIPTION
1. elastic search에서는 이미 관련도 내림차순으로 출력을 하기 때문에 결과 그대로의 값을 출력하면 해결 가능하다.
2. 프론트 구역에서 해당 내용을 추가한다.