### PR TITLE
#182 - 2차 QA 중 나온 버그 해결

### DIFF
--- a/front_end/src/components/account/com_orders_unit.vue
+++ b/front_end/src/components/account/com_orders_unit.vue
@@ -27,7 +27,7 @@
                     v-for="item in btns" :key="item"
                     color="primary"
                     @click="item.click"
-                    :disabled="item.banState.includes(state)"
+                    :disabled="isBan(item, state)"
                 >{{ item.label }}</v-btn>
             </div>
         </v-card>
@@ -59,11 +59,14 @@ data() {return {
         btnExchange: {
             label: "취소 신청",
             click: this.onClickCancellation,
-            banState: ["CANCEL"],
+            banState: ["READY", "CANCEL"],
         },
     },
 }},
 methods: {
+    isBan(item, state) {
+        return item.banState.includes(state) || !this.$store.getters.isUser;
+    },
     transState(state) {
         let origin = this.$env.com_orders;
         return this.$env.util_com_orders(origin, state, "name");

--- a/front_end/src/components/com_account_nav.vue
+++ b/front_end/src/components/com_account_nav.vue
@@ -6,7 +6,7 @@
             <v-divider class="my-3" />
         </div>
 
-        <div class="t2b pa-4 bg-nav" v-if="confirmAuth(['SELLER', 'USER'])">
+        <div class="t2b pa-4 bg-nav" v-if="confirmAuth(['USER'])">
             <h2 class="mb-4">MY 쇼핑</h2>
             <p class="clickable link" @click="$router.push($endPoint.myPage);"
             >구매 조회</p>
@@ -36,6 +36,9 @@
             <h2 class="mb-4">MY 판매</h2>
             <p class="clickable link" @click="$router.push($endPoint.createItem);"
             >상품 생성</p>
+
+            <p class="clickable link" @click="$router.push($endPoint.myPage);"
+            >구매 현황</p>
 
             <v-divider class="my-3" />
         </div>

--- a/front_end/src/components/header/com_tools.vue
+++ b/front_end/src/components/header/com_tools.vue
@@ -3,6 +3,7 @@
         class="d-flex align-center"
     >
         <v-btn 
+            v-if="isUser"
             @click="btnHolder.click"
             stacked
         >
@@ -63,6 +64,9 @@ export default {
     computed: {
         isLogin() {
             return this.$store.getters.isLogin;
+        },
+        isUser() {
+            return this.$store.getters.isUser;
         },
     },
     methods: {


### PR DESCRIPTION
1.판매자로 로그인 시, 좌측 네비게이션 바에 'MY 쇼핑' 항목을 'MY 판매' 쪽에 이동시키기.
2. 마이 페이지에서 찜한 목록은 취소 신청하지 못하게 disable 시키기.
3. 판매자로 로그인 시, 자바구니 버튼 disable