### PR TITLE
#185 - deprecated된 ElasticSearchConfig 설정 교정

### DIFF
--- a/back_end/build.gradle
+++ b/back_end/build.gradle
@@ -53,6 +53,8 @@ dependencies {
 
 //	elasticsearch search 적용
 	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'jakarta.json:jakarta.json-api:2.0.1'
 
 //	amazon S3 적용
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'

--- a/back_end/src/main/java/com/project/shoppingmall/config/ElasticSearchConfig.java
+++ b/back_end/src/main/java/com/project/shoppingmall/config/ElasticSearchConfig.java
@@ -3,28 +3,25 @@ package com.project.shoppingmall.config;
 import com.project.shoppingmall.config.properties.ElasticSearchProperties;
 import com.project.shoppingmall.repository.ItemRepository;
 import lombok.RequiredArgsConstructor;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
-import org.springframework.data.elasticsearch.client.RestClients;
-import org.springframework.data.elasticsearch.config.AbstractElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
 import org.springframework.data.elasticsearch.config.EnableElasticsearchAuditing;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+import java.net.InetSocketAddress;
 
 @EnableElasticsearchRepositories(basePackageClasses = {ItemRepository.class})
 @EnableElasticsearchAuditing
 @RequiredArgsConstructor
 @Configuration
-public class ElasticSearchConfig extends AbstractElasticsearchConfiguration {
+public class ElasticSearchConfig extends ElasticsearchConfiguration {
     private final ElasticSearchProperties esProperties;
 
     @Override
-    public RestHighLevelClient elasticsearchClient() {
-        ClientConfiguration clientConfiguration = ClientConfiguration.builder()
-                .connectedTo(
-                        String.format("%s:%s", esProperties.getHost(), esProperties.getPort())
-                )
+    public ClientConfiguration clientConfiguration() {
+        return ClientConfiguration.builder()
+                .connectedTo(new InetSocketAddress(esProperties.getHost(), esProperties.getPort()))
                 .build();
-        return RestClients.create(clientConfiguration).rest();
     }
 }

--- a/back_end/src/main/java/com/project/shoppingmall/repository/querydsl/ItemRepositoryImpl.java
+++ b/back_end/src/main/java/com/project/shoppingmall/repository/querydsl/ItemRepositoryImpl.java
@@ -1,23 +1,17 @@
 package com.project.shoppingmall.repository.querydsl;
 
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import com.project.shoppingmall.domain.Item;
 import com.project.shoppingmall.domain.nested.Tag;
 import com.project.shoppingmall.repository.KeywordRepository;
 import com.project.shoppingmall.utils.ElasticSearchOperationsUtil;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
-import org.elasticsearch.search.aggregations.bucket.terms.ParsedStringTerms;
-import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 
-import java.util.Collection;
 import java.util.List;
-
-import static org.elasticsearch.index.query.QueryBuilders.*;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 
 public class ItemRepositoryImpl implements KeywordRepository<Item> {
     private final ElasticSearchOperationsUtil<Item> fetchUtil;
@@ -29,30 +23,35 @@ public class ItemRepositoryImpl implements KeywordRepository<Item> {
 
     @Override
     public Page<Item> findByKeyword(String keyword, Pageable pageable) {
-        QueryBuilder query = boolQuery()
-                .should(matchQuery("name", keyword))
-                .should(matchQuery("tagList.name", keyword));
-
-        return fetchUtil.fetchWithPageable(query, pageable);
+        Query nameQuery = new Query.Builder().match(q -> q.field("name").query(keyword)).build();
+        Query tagNameQuery = new Query.Builder().match(q -> q.field("tagList.name").query(keyword)).build();
+        return fetchUtil.fetchWithPageable(
+                b -> b.withQuery(q -> q.bool(bool -> bool.should(nameQuery, tagNameQuery))),
+                pageable
+        );
     }
 
     @Override
     public List<Tag> findDistinctTag() {
         String AGG_NAME = "distinct_tags";
-        TermsAggregationBuilder query = terms(AGG_NAME).field("tagList.name");
-
-        return fetchUtil.fetchAggregation(matchAllQuery(), ParsedStringTerms.class, AGG_NAME, query)
-                .map(ParsedStringTerms::getBuckets)
-                .stream().flatMap(Collection::stream)
-                .map(MultiBucketsAggregation.Bucket::getKeyAsString)
+        Aggregation aggregation = Aggregation.of(
+                builder -> builder.terms(t -> t.field("tagList.name"))
+        );
+        return fetchUtil.fetchCountsDict(
+                builder -> builder
+                        .withQuery(b -> b.matchAll(m -> m))
+                        .withAggregation(AGG_NAME, aggregation)
+                ).keySet().stream()
                 .map(s -> Tag.builder().name(s).build())
                 .toList();
     }
 
     @Override
     public Page<Item> findByTagName(String tagName, Pageable pageable) {
-        QueryBuilder query = matchQuery("tagList.name", tagName);
-
-        return fetchUtil.fetchWithPageable(query, pageable);
+        return fetchUtil.fetchWithPageable(
+                b -> b.withQuery(
+                        q -> q.match(m -> m.field("tagList.name").query(tagName))
+                ),
+                pageable);
     }
 }

--- a/back_end/src/main/java/com/project/shoppingmall/repository/querydsl/ReviewRepositoryImpl.java
+++ b/back_end/src/main/java/com/project/shoppingmall/repository/querydsl/ReviewRepositoryImpl.java
@@ -1,21 +1,13 @@
 package com.project.shoppingmall.repository.querydsl;
 
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
 import com.project.shoppingmall.domain.Review;
 import com.project.shoppingmall.repository.CustomReviewRepository;
 import com.project.shoppingmall.utils.ElasticSearchOperationsUtil;
-import org.elasticsearch.index.query.MatchQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.search.aggregations.AggregationBuilders;
-import org.elasticsearch.search.aggregations.metrics.Avg;
-import org.elasticsearch.search.aggregations.metrics.AvgAggregationBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
-
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
-import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 
 public class ReviewRepositoryImpl implements CustomReviewRepository {
     private final ElasticSearchOperationsUtil<Review> fetchUtil;
@@ -25,51 +17,49 @@ public class ReviewRepositoryImpl implements CustomReviewRepository {
         this.fetchUtil = new ElasticSearchOperationsUtil<>(Review.class, elasticsearchClient);
     }
 
-    private MatchQueryBuilder queryForFindWithItemId(String iid) {
-        return matchQuery("item.id", iid);
-    }
-    private MatchQueryBuilder queryForFindWithUserId(Long uid) {
-        return matchQuery("user.id", uid);
-    }
-    private MatchQueryBuilder queryForFindWithSellerId(Long uid) {
-        return matchQuery("item.seller", uid);
-    }
-
     @Override
     public Page<Review> findReviewByItemId(String iid, Pageable pageable) {
-        QueryBuilder query = queryForFindWithItemId(iid);
-
-        return fetchUtil.fetchWithPageable(query, pageable);
+        return fetchUtil.fetchWithPageable(
+                b -> b.withQuery(q -> q.match(bool -> bool.field("item.id").query(iid))),
+                pageable);
     }
 
     @Override
     public Page<Review> findReviewByUserId(Long uid, Pageable pageable) {
-        QueryBuilder query = queryForFindWithUserId(uid);
-
-        return fetchUtil.fetchWithPageable(query, pageable);
+        return fetchUtil.fetchWithPageable(
+                b -> b.withQuery(q -> q.match(bool -> bool.field("user.id").query(uid))),
+                pageable);
     }
 
     @Override
     public Page<Review> findReviewBySellerId(Long uid, Pageable pageable) {
-        QueryBuilder query = queryForFindWithSellerId(uid);
-
-        return fetchUtil.fetchWithPageable(query, pageable);
+        return fetchUtil.fetchWithPageable(
+                b -> b.withQuery(q -> q.match(bool -> bool.field("item.seller").query(uid))),
+                pageable);
     }
 
     @Override
     public Page<Review> searchReviewByKeyword(String keyword, Pageable pageable) {
-        QueryBuilder query = boolQuery().should(QueryBuilders.matchQuery("content", keyword));
-
-        return fetchUtil.fetchWithPageable(query, pageable);
+        return fetchUtil.fetchWithPageable(
+                b -> b.withQuery(q -> q.bool(
+                        bool -> bool.should(
+                                s -> s.match(m -> m.field("content").query(keyword)))
+                        )
+                ),
+                pageable);
     }
 
     @Override
     public Double getAverageByItemId(String iid) {
         String AggName = "AVG";
-        AvgAggregationBuilder aggregation = AggregationBuilders.avg(AggName).field("rating");
-
-        return fetchUtil.fetchAggregation(queryForFindWithItemId(iid), Avg.class, AggName, aggregation)
-                .map(Avg::getValue)
+        Aggregation aggregation = Aggregation.of(
+                builder -> builder.avg(t -> t.field("rating"))
+        );
+        return fetchUtil.fetchAvg(
+                        builder -> builder
+                                .withQuery(q -> q.match(bool -> bool.field("item.id").query(iid)))
+                                .withAggregation(AggName, aggregation)
+                )
                 .filter(d -> !Double.isNaN(d))
                 .filter(d -> !Double.isInfinite(d))
                 .orElse(0d);

--- a/back_end/src/main/java/com/project/shoppingmall/utils/ElasticSearchOperationsUtil.java
+++ b/back_end/src/main/java/com/project/shoppingmall/utils/ElasticSearchOperationsUtil.java
@@ -1,30 +1,34 @@
 package com.project.shoppingmall.utils;
 
+import co.elastic.clients.elasticsearch._types.aggregations.*;
 import lombok.AllArgsConstructor;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
-import org.elasticsearch.search.sort.SortBuilder;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.elasticsearch.core.ElasticsearchAggregations;
+import org.springframework.data.elasticsearch.client.elc.Aggregation;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchAggregation;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.client.elc.NativeQueryBuilder;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
-import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @AllArgsConstructor
 public class ElasticSearchOperationsUtil<T> {
     private final Class<T> clazz;
     private final ElasticsearchOperations elasticsearchClient;
 
-    public Page<T> fetchWithPageable(QueryBuilder query, Pageable pageable) {
+    public Page<T> fetchWithPageable(Function<NativeQueryBuilder, NativeQueryBuilder> queryFunction, Pageable pageable) {
         SearchHits<T> result = elasticsearchClient.search(
-                new NativeSearchQueryBuilder()
-                        .withQuery(query)
+                queryFunction.apply(NativeQuery.builder())
                         .withPageable(pageable)
                         .build(),
                 this.clazz
@@ -36,39 +40,9 @@ public class ElasticSearchOperationsUtil<T> {
         return new PageImpl<>(items, pageable, result.getTotalHits());
     }
 
-    public Page<T> fetchWithSorting(QueryBuilder query, SortBuilder<?> sortBuilder) {
+    public Optional<T> fetchOne(Function<NativeQueryBuilder, NativeQueryBuilder> queryFunction) {
         SearchHits<T> result = elasticsearchClient.search(
-                new NativeSearchQueryBuilder()
-                        .withQuery(query)
-                        .withSorts(sortBuilder)
-                        .build(),
-                this.clazz
-        );
-
-        List<T> items = result.getSearchHits().stream()
-                .map(SearchHit::getContent)
-                .toList();
-        return new PageImpl<>(items, Pageable.unpaged(), result.getTotalHits());
-    }
-
-    public List<T> fetch(QueryBuilder query) {
-        SearchHits<T> result = elasticsearchClient.search(
-                new NativeSearchQueryBuilder()
-                        .withQuery(query)
-                        .build(),
-                this.clazz
-        );
-
-        return result.getSearchHits().stream()
-                .map(SearchHit::getContent)
-                .toList();
-    }
-
-    public Optional<T> fetchOne(QueryBuilder query) {
-        SearchHits<T> result = elasticsearchClient.search(
-                new NativeSearchQueryBuilder()
-                        .withQuery(query)
-                        .build(),
+                queryFunction.apply(NativeQuery.builder()).build(),
                 this.clazz
         );
 
@@ -78,25 +52,37 @@ public class ElasticSearchOperationsUtil<T> {
                 .map(SearchHit::getContent);
     }
 
-    public <U> Optional<U> fetchAggregation(
-            QueryBuilder query,
-            Class<U> castTo,
-            String AggName,
-            AbstractAggregationBuilder<?>... aggregationBuilder
+    public Stream<Aggregate> fetchAggregation(
+            Function<NativeQueryBuilder, NativeQueryBuilder> queryFunction
     ) {
         SearchHits<T> result = elasticsearchClient.search(
-                new NativeSearchQueryBuilder()
-                        .withQuery(query)
-                        .withAggregations(aggregationBuilder)
-                        .build(),
+                queryFunction.apply(NativeQuery.builder()).build(),
                 this.clazz
         );
 
-        return Optional.of(result)
-                .map(SearchHits::getAggregations)
-                .map(ElasticsearchAggregations.class::cast)
-                .map(ElasticsearchAggregations::aggregations)
-                .map(aggregations -> aggregations.get(AggName))
-                .map(castTo::cast);
+        List<ElasticsearchAggregation> aggregations = (List) result.getAggregations().aggregations();
+        return aggregations.stream()
+                .map(ElasticsearchAggregation::aggregation)
+                .map(Aggregation::getAggregate);
+    }
+
+    public Map<String, Long> fetchCountsDict(
+            Function<NativeQueryBuilder, NativeQueryBuilder> queryFunction
+    ) {
+        return fetchAggregation(queryFunction)
+                .map(Aggregate::sterms)
+                .map(StringTermsAggregate::buckets)
+                .map(Buckets::array)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toMap(StringTermsBucket::key, StringTermsBucket::docCount));
+    }
+
+    public Optional<Double> fetchAvg(
+            Function<NativeQueryBuilder, NativeQueryBuilder> queryFunction
+    ) {
+        return fetchAggregation(queryFunction)
+                .map(Aggregate::avg)
+                .map(AvgAggregate::value)
+                .findFirst();
     }
 }


### PR DESCRIPTION
문제 상황: 기존에 설정했던 Elastic Search 관련 환경 설정 시, RestHighLevelClient를 사용하였다.
       이는 Spring Data Elasticsearch 4.2.x 에서 4.3.x로 버전업 될 때, deprecated되었다.
       현재는 4.4.5 버전을 사용해야 하기 때문에 이를 무조건 해결해야 했다.
1. ElasticSearchConfig 파일의 내용을 수정.
2. 의존성 추가. - json 관련 & WebClient 관련
3. 기존에 사용했던 NativeSearchQueryBuilder이 더 이상 호환되지 않아 RepositoryImpl 수정.